### PR TITLE
Wrong parameter type

### DIFF
--- a/releases/0.10/documentation/tutorial/connect-database.md
+++ b/releases/0.10/documentation/tutorial/connect-database.md
@@ -72,7 +72,7 @@ import reactivemongo.core.nodeset.Authenticate
 val dbName = "somedatabase"
 val userName = "username"
 val password = "password"
-val credentials = List(Authenticate(dbName, userName, password))
+val credentials = Seq(Authenticate(dbName, userName, password))
 val connection = driver.connection(servers, nbChannelsPerNode = 5, authentications = credentials))
 {% endhighlight %}
 


### PR DESCRIPTION
For authentication, the `connection` method takes a `Seq` and not a `List` for the credentials (see http://reactivemongo.org/releases/0.10/api/index.html#reactivemongo.api.MongoDriver)
