### PR TITLE
Fix typo in code example

### DIFF
--- a/releases/0.10/documentation/advanced-topics/read-preferences.md
+++ b/releases/0.10/documentation/advanced-topics/read-preferences.md
@@ -21,7 +21,7 @@ Read preference are given to `GenericQueryBuilder.cursor()` and `GenericQueryBui
 collection.
   find(BSONDocument("city" -> "San Francisco")).
   // read from any secondary whenever possible
-  cursor(ReadPreferences.secondaryPrefered).
+  cursor(ReadPreference.secondaryPrefered).
   collect[List]()
 {% endhighlight %}
 


### PR DESCRIPTION
consider compiling and running your code examples for more correctness! The sbt-site plugin makes this possible for example. We use this in https://github.com/slick/slick
