### PR TITLE
Missing import in index example

### DIFF
--- a/index.md
+++ b/index.md
@@ -93,6 +93,7 @@ A `MongoDriver` instance manages an actor system; a `connection` manages a pool 
 {% highlight scala %}
 import reactivemongo.api._
 import reactivemongo.bson._
+import scala.concurrent.Future
 
 import scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
Without this import, `sbt compile` gives:

```
[error]     var futureList : Future[List[BSONDocument]] =
[error]                      ^
[error] one error found
[error] (compile:compile) Compilation failed
```
