### PR TITLE
Fix SSL support link in release details

### DIFF
--- a/releases/0.11.0/documentation/release-details.md
+++ b/releases/0.11.0/documentation/release-details.md
@@ -13,7 +13,7 @@ Enhancements:
 
 - New APIs, for the commands and [streaming](tutorial/consume-streams.html)
 - Compatibility with MongoDB 3
-- [SSL support](tutorial/setup.md)
+- [SSL support](tutorial/connect-database.html)
 - Builtin micro-DSL for BSON
 - Convenient operations on a collection (`.count`, `.runCommand`)
 


### PR DESCRIPTION
Old link was broken, information about SSL support can be found on connect-database.html
