### PR TITLE
Bad WriteResult for duplicate insert example

### DIFF
--- a/releases/0.11/documentation/tutorial/write-documents.md
+++ b/releases/0.11/documentation/tutorial/write-documents.md
@@ -69,12 +69,12 @@ When calling a write operation, it's possible to handle some specific error case
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import reactivemongo.api.commands.WriteResult
+import reactivemongo.api.commands.{ CommandError, WriteResult }
 
 val future: Future[WriteResult] = collection.insert(person)
 
-val end: Future[Unit] = future.map {
-  case writeResult if (writeResult.code contains 11000) =>
+val end: Future[Unit] = future.map(_ => {}).recover {
+  case err: CommandError if (err.code contains 11000) =>
     // if the result is defined with the error code 11000 (duplicate error)
     println("Just a warning")
 

--- a/releases/0.12/documentation/tutorial/write-documents.md
+++ b/releases/0.12/documentation/tutorial/write-documents.md
@@ -69,12 +69,12 @@ When calling a write operation, it's possible to handle some specific error case
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import reactivemongo.api.commands.WriteResult
+import reactivemongo.api.commands.{ CommandError, WriteResult }
 
 val future: Future[WriteResult] = collection.insert(person)
 
-val end: Future[Unit] = future.map {
-  case writeResult if (writeResult.code contains 11000) =>
+val end: Future[Unit] = future.map(_ => {}).recover {
+  case err: CommandError if (err.code contains 11000) =>
     // if the result is defined with the error code 11000 (duplicate error)
     println("Just a warning")
 


### PR DESCRIPTION
In the documentation (http://reactivemongo.org/releases/0.11/documentation/tutorial/write-documents.html) there is an example about error handling in case of a duplicate document:

> When calling a write operation, it’s possible to handle some specific error case by testing the result.
> 
> ``` scala
> val future: Future[WriteResult] = collection.insert(person)
> 
> val end: Future[Unit] = future.map {
>   case writeResult if (writeResult.code contains 11000) =>
>     // if the result is defined with the error code 11000 (duplicate error)
>     println("Just a warning")
> 
>   case _ => ()
> }
> ```

At the same time, the page says:

> If the write result actually indicates an error, the Future will be in a failed state.

Seems to me that the "Just  a warning" message will never be printed, because the function given to `map` is never run in case a "duplicate error" occurs, ie. when the Future is in a failed state.
