### PR TITLE
Network/connectivity troubleshooting

### DIFF
--- a/releases/0.12/documentation/release-details.md
+++ b/releases/0.12/documentation/release-details.md
@@ -1132,7 +1132,7 @@ As for SLF4J is now used, the following error is raised, please make sure to pro
 
 In order to debug the networking issues, the internal state of the node set is provided as details of the related exceptions, as bellow.
 
-{% highlight text %}
+{% highlight text %}{% raw %}
 reactivemongo.core.actors.Exceptions$InternalState: null (<time:1469208071685>:-1)
 reactivemongo.ChannelClosed(-2079537712, {{NodeSet None Node[localhost:27017: Primary (0/0 available connections), latency=5], auth=Set() }})(<time:1469208071685>)
 reactivemongo.Shutdown(<time:1469208071673>)
@@ -1148,7 +1148,7 @@ reactivemongo.ChannelDisconnected(-228911231, {{NodeSet None Node[localhost:2701
 reactivemongo.ChannelClosed(-562085577, {{NodeSet None Node[localhost:27017: Primary (5/6 available connections), latency=5], auth=Set() }})(<time:1469208071662>)
 reactivemongo.ChannelDisconnected(-562085577, {{NodeSet None Node[localhost:27017: Primary (6/6 available connections), latency=5], auth=Set() }})(<time:1469208071662>)
 reactivemongo.ChannelClosed(-857553810, {{NodeSet None Node[localhost:27017: Primary (6/7 available connections), latency=5], auth=Set() }})(<time:1469208071662>)
-{% endhighlight %}
+{% endraw %}{% endhighlight %}
 
 ### Monitoring
 


### PR DESCRIPTION
**Primary not available:**
- In logs: "The primary is unavailable, is there a network problem?"
- Exception: `reactivemongo.core.actors.Exceptions$PrimaryUnavailableException: MongoError['No primary node is available! ...']`

**Node set not reachable:**
- In logs: "The entire node set is unreachable, is there a network problem?"
- Exception: `reactivemongo.core.actors.Exceptions$NodeSetNotReachable: MongoError['The node set can not be reached! Please check your network connectivity ...']`

**Troubleshooting:**
1. Check the DB nodes are accessible from the node running the application.
   - Tools: MongoShell, SBT Playground
   - Possible issues: broken network, authentication (before 0.12, MONGOCR is the default mode), SSL issue.
2. Check the connection URI used with ReactiveMongo.
   - Actions: Remove non mandatory options (e.g. `connectTimeoutMS`); Check the authentication options (according _1_).
   - Tools: SBT Playground (to tests URI variants)
3. If connecting to a Mongo ReplicaSet, check the status (e.g. `rs.status()` from the MongoShell).
4. If the [ReactiveMongo logging](http://reactivemongo.org/releases/0.12/documentation/tutorial/setup.html#logging) is enabled, check the messages from the loggers in `reactivemongo.core`.
5. Possibily using the JMX module to check how the node set is seen by the driver.
