### PR TITLE
Play module documentation links

### DIFF
--- a/releases/0.1x/documentation/tutorial/play.md
+++ b/releases/0.1x/documentation/tutorial/play.md
@@ -16,12 +16,12 @@ The latest version of this plugin is for Play 2.4+, and can be enabled by adding
 {% highlight ocaml %}
 // only for Play 2.6.x (Scala 2.12)
 libraryDependencies ++= Seq(
-  "org.reactivemongo" %% "play2-reactivemongo" % "{{page._0_1x_latest_minor_play_module}}-play26"
+  "org.reactivemongo" %% "play2-reactivemongo" % "{{page._0_1x_latest_minor_play_module}}"
 )
 
 // only for Play 2.5.x (Scala 2.11)
 libraryDependencies ++= Seq(
-  "org.reactivemongo" %% "play2-reactivemongo" % "{{page._0_1x_latest_minor_play_module}}-play25"
+  "org.reactivemongo" %% "play2-reactivemongo" % "{{site._0_1x_latest_minor}}-play25"
 )
 {% endhighlight %}
 

--- a/releases/0.1x/documentation/tutorial/play.md
+++ b/releases/0.1x/documentation/tutorial/play.md
@@ -2,9 +2,10 @@
 layout: default
 major_version: 0.1x
 title: Integration with Play Framework
+_0_1x_latest_minor_play_module: 0.16.0-play26
 ---
 
-A ReactiveMongo plugin is available for [Play Framework](https://playframework.com/), providing a reactive, asynchronous and non-blocking Scala driver for MongoDB to develop your application.
+A ReactiveMongo plugin is available for [Play Framework](https://playframework.com/), providing a reactive, asynchronous and non-blocking Scala driver for MongoDB to develop your application {{page.kaka}}.
 
 This module is based on the [Play JSON serialization](../json/overview.html).
 
@@ -15,12 +16,12 @@ The latest version of this plugin is for Play 2.4+, and can be enabled by adding
 {% highlight ocaml %}
 // only for Play 2.6.x (Scala 2.12)
 libraryDependencies ++= Seq(
-  "org.reactivemongo" %% "play2-reactivemongo" % "{{site._0_1x_latest_minor}}-play26"
+  "org.reactivemongo" %% "play2-reactivemongo" % "{{page._0_1x_latest_minor_play_module}}-play26"
 )
 
 // only for Play 2.5.x (Scala 2.11)
 libraryDependencies ++= Seq(
-  "org.reactivemongo" %% "play2-reactivemongo" % "{{site._0_1x_latest_minor}}-play25"
+  "org.reactivemongo" %% "play2-reactivemongo" % "{{page._0_1x_latest_minor_play_module}}-play25"
 )
 {% endhighlight %}
 
@@ -30,9 +31,9 @@ libraryDependencies ++= Seq(
 
 As for Play itself, this ReactiveMongo plugin requires a JVM 1.8+.
 
-The [API of this Play module](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/play2-reactivemongo_2.12/{{site._0_1x_latest_minor}}/play2-reactivemongo_2.12-{{site._0_1x_latest_minor}}-javadoc.jar/!/index.html) can be browsed online.
+The [API of this Play module](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/play2-reactivemongo_2.12/{{page._0_1x_latest_minor_play_module}}/play2-reactivemongo_2.12-{{page._0_1x_latest_minor_play_module}}-javadoc.jar/!/index.html) can be browsed online.
 
-The API for the standalone JSON serialization is [also available](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/reactivemongo-play-json_2.12/{{site._0_1x_latest_minor}}/reactivemongo-play-json_2.12-{{site._0_1x_latest_minor}}-javadoc.jar/!/index.html).
+The API for the standalone JSON serialization is [also available](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/reactivemongo-play-json_2.12/{{page._0_1x_latest_minor_play_module}}/reactivemongo-play-json_2.12-{{page._0_1x_latest_minor_play_module}}-javadoc.jar/!/index.html).
 
 If you want to use the latest snapshot, add the following instead (only for play > 2.4):
 
@@ -50,7 +51,7 @@ libraryDependencies ++= Seq(
 
 **`ReactiveMongoPlugin` is deprecated, long live to `ReactiveMongoModule` and `ReactiveMongoApi`**.
 
-Play has deprecated the plugins in version 2.4, therefore it is recommended to remove the former `ReactiveMongoPlugin` from your project. It must be replaced it by `ReactiveMongoModule` and [`ReactiveMongoApi`](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/play2-reactivemongo_2.12/{{site._0_1x_latest_minor}}/play2-reactivemongo_2.12-{{site._0_1x_latest_minor}}-javadoc.jar/!/index.html#play.modules.reactivemongo.ReactiveMongoApi) which is the interface to MongoDB.
+Play has deprecated the plugins in version 2.4, therefore it is recommended to remove the former `ReactiveMongoPlugin` from your project. It must be replaced it by `ReactiveMongoModule` and [`ReactiveMongoApi`](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/play2-reactivemongo_2.12/{{page._0_1x_latest_minor_play_module}}/play2-reactivemongo_2.12-{{page._0_1x_latest_minor_play_module}}-javadoc.jar/!/index.html#play.modules.reactivemongo.ReactiveMongoApi) which is the interface to MongoDB.
 
 Thus, the dependency injection can be configured, so that the your controllers are given the new ReactiveMongo API.
 First, Add the line bellow to `application.conf`:
@@ -77,7 +78,7 @@ class MyController @Inject() (
 }
 {% endhighlight %}
 
-The traits [`ReactiveMongoComponents`](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/play2-reactivemongo_2.12/{{site._0_1x_latest_minor}}/play2-reactivemongo_2.12-{{site._0_1x_latest_minor}}-javadoc.jar/!/index.html#play.modules.reactivemongo.ReactiveMongoComponents) and [`ReactiveMongoApiComponents`](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/play2-reactivemongo_2.12/{{site._0_1x_latest_minor}}/play2-reactivemongo_2.12-{{site._0_1x_latest_minor}}-javadoc.jar/!/index.html#play.modules.reactivemongo.ReactiveMongoApiComponents) can be used for [compile-time dependency injection](https://playframework.com/documentation/latest/ScalaCompileTimeDependencyInjection).
+The traits [`ReactiveMongoComponents`](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/play2-reactivemongo_2.12/{{site._0_1x_latest_minor_play_module}}/play2-reactivemongo_2.12-{{site._0_1x_latest_minor_play_module}}-javadoc.jar/!/index.html#play.modules.reactivemongo.ReactiveMongoComponents) and [`ReactiveMongoApiComponents`](https://oss.sonatype.org/service/local/repositories/releases/archive/org/reactivemongo/play2-reactivemongo_2.12/{{site._0_1x_latest_minor_play_module}}/play2-reactivemongo_2.12-{{site._0_1x_latest_minor_play_module}}-javadoc.jar/!/index.html#play.modules.reactivemongo.ReactiveMongoApiComponents) can be used for [compile-time dependency injection](https://playframework.com/documentation/latest/ScalaCompileTimeDependencyInjection).
 
 {% highlight scala %}
 import javax.inject.Inject


### PR DESCRIPTION
Tried to fix the links, but apparently something is also wrong with docs themselves.